### PR TITLE
Update app manifest for supporting custom title bar in unpackaged apps

### DIFF
--- a/src/VisualSortingItems/Properties/launchSettings.json
+++ b/src/VisualSortingItems/Properties/launchSettings.json
@@ -1,10 +1,10 @@
 {
   "profiles": {
-    "VisualSortingItems (Package)": {
-      "commandName": "MsixPackage"
-    },
     "VisualSortingItems (Unpackaged)": {
       "commandName": "Project"
+    },
+    "VisualSortingItems (Package)": {
+      "commandName": "MsixPackage"
     }
   }
 }

--- a/src/VisualSortingItems/VisualSortingItems.csproj
+++ b/src/VisualSortingItems/VisualSortingItems.csproj
@@ -19,8 +19,8 @@
 		     When selecting the labeled "Unpackaged" project from the launch debugging experience, 
 			 this property should be None. -->
 		
-		<!--<WindowsPackageType>None</WindowsPackageType>-->
-		<WindowsPackageType>MSIX</WindowsPackageType>
+		<WindowsPackageType>None</WindowsPackageType>
+		<!--<WindowsPackageType>MSIX</WindowsPackageType>-->
 	</PropertyGroup>
 
 

--- a/src/VisualSortingItems/app.manifest
+++ b/src/VisualSortingItems/app.manifest
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity version="1.0.0.0" name="VisualSortingItems.app"/>
-
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<!--The ID below indicates app support for Windows 8 
+                Also, it's needed for some APIs in unpackaged scenarios -->
+			<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+		</application>
+	</compatibility>
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <!-- The combination of below two tags have the following effect:
            1) Per-Monitor for >= Windows 10 Anniversary Update


### PR DESCRIPTION
- Update app manifest for supporting custom title bar unpackaged.
- Setting unpackaged as default configuration